### PR TITLE
Optimize Dockerfile for reduced image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,19 @@
 FROM debian:buster-slim
 MAINTAINER Robin Grönerg <robingronberg@gmail.com>
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y \
-    procps python3 python3-setuptools python3-pip curl sqlite3 && \
+ENV VERSION=7.1.5
+ENV DOCKERIZE_VERSION v0.6.1
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y --no-install-recommends \
+    procps python3 python3-dev python3-setuptools python3-pip python3-wheel curl sqlite3 && \
   pip3 install --timeout=3600 \
     Pillow pylibmc captcha jinja2 sqlalchemy python3-ldap \
     django-pylibmc django-simple-captcha && \
-  apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-ENV DOCKERIZE_VERSION v0.6.1
-RUN curl -L https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz | tar -xz -C /usr/local/bin
-
-ENV VERSION=7.1.5
-RUN useradd -d /seafile -M -s /bin/bash -c "Seafile User" seafile \
+  apt-get purge -y python3-dev python3-setuptools python3-pip python3-wheel && \
+  apt-get autoremove -y && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /root/.cache /usr/share/doc/* && \
+  find / -type f -name '*.py[co]' -delete -or -type d -name '__pycache__' -delete && \
+  curl -L https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz | tar -xz -C /usr/local/bin && \
+  useradd -d /seafile -M -s /bin/bash -c "Seafile User" seafile \
   && mkdir -p /opt/haiwen /seafile/ \
   && curl -sL $(curl -sL https://www.seafile.com/en/download/ \
     | grep -oE 'https://.*seafile-server.*x86-64.tar.gz' \


### PR DESCRIPTION
This PR moves some things around in the Dockerfile focusing on reducing the image size:

- Merge all `RUN` commands into one
- Removing dependencies that are only required for building (and _their_ dependences too, with `apt-get autoremove`)
- Disabling the installation of APT's recommended packages (which also meant adding `python3-dev` and `python3-wheel` to the list because they were installed as recommended but were actually required)
- Removing all Python bytecode files from the image (they will be recreated as needed the first time)
- Removing `pip` cache and unused docs
- Removed `apt-get clean` since [it's already being done internally with better results](https://github.com/rocker-org/rocker/issues/35#issuecomment-58944297)

Before: **695 MB in 5 layers**
After: **298 MB in 3 layers**

That's less than half with (I hope) no change in functionality :)