### PR TITLE
Upgrade Seafile version from 8.0.4 to 8.0.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:buster-slim
 MAINTAINER Robin Grönerg <robingronberg@gmail.com>
 
-ENV VERSION=8.0.4
+ENV VERSION=8.0.5
 ENV DOCKERIZE_VERSION v0.6.1
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Official changelog: https://manual.seafile.com/changelog/server-changelog/#805-20210514

> 8.0.5 (2021/05/14)
> Add "Open via Client" button in file view page
> Add an admin API to change a user's email
> [fix] Fix a bug in seaf-gc
> [fix] Fix wrong links of files in library history details dialog
> [fix] Fix deleting libraries without owner in admin panel
> [fix] Fix a XSS problem in notification
> [fix] Fix JWT token support in OnlyOffice integration
> [fix] Fix sometimes webdav cache files are not cleaned