### PR TITLE
Fix seafdav not working

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y --no-ins
     build-essential autoconf libtool pkg-config \
     libffi-dev libjpeg-dev zlib1g-dev && \
   pip3 install --timeout=3600 \
-    Pillow pylibmc captcha jinja2 sqlalchemy python3-ldap \
+    Pillow pylibmc captcha jinja2 "sqlalchemy<2" python3-ldap \
     django-pylibmc django-simple-captcha mysqlclient lxml \
     future pycryptodome==3.12.0 cffi==1.14.0 && \
   apt-get purge -y \


### PR DESCRIPTION
Pin `sqlalchemy<2` as the latest major release introduced changes not backward compatible with the Python modules included with Seafile. This enables `seafdav` to work correctly. The official docker image employed a similar [fix](https://github.com/haiwen/seafile-docker/commit/7481afa74563c9238ea7a3addf909cf7f3ab6ca1) for the v10 beta release but this change hasn't been backported to images for older releases.

Relevant issue upstream: https://github.com/haiwen/seafile/issues/2645